### PR TITLE
Reinstate tests for CouchDB 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     - DOCKERIMAGE=rfc1149/couchdb:1.x.x
     - DOCKERIMAGE=klaemo/couchdb:2.0.0
+    - DOCKERIMAGE=apache/couchdb:2.1.0
   global:
     secure: ALtSdAp4wFe55/RY2+XYL8zkpwmxlIUpklbfIVzfvB+8rMMOyRxDnVbQX8DAZEqgTvQpddghOJLbqJTXwfF1MuuSVMsRpa8/iCgl6dB4fCv4YlHaLK0mb96ca0vFV0dUnp+gy9u3tNkuVAWzqlDkPf2lMreYkKlNqiqGELsFOp4=
 before_install:

--- a/src/test/scala/WithDbSpecification.scala
+++ b/src/test/scala/WithDbSpecification.scala
@@ -43,7 +43,9 @@ abstract class WithDbSpecification(dbSuffix: String) extends Specification {
   def waitForEnd[T](fs: Future[T]*): Unit = Await.ready(Future.sequence(fs), timeout)
 
   lazy val isCouchDB1 = waitForResult(couch.isCouchDB1)
+  lazy val isCouchDB20 = waitForResult(couch.status().map(_.version.startsWith("2.0")))
 
   def pendingIfNotCouchDB1(msg: String) = if (!isCouchDB1) pending(s"[pending: $msg]")
+  def pendingIfCouchDB20(msg: String) = if (isCouchDB20) pending(s"[pending: $msg]")
 
 }


### PR DESCRIPTION
Those tests correspond to bugs that were present in CouchDB 2.0
and have been fixed in CouchDB 2.1.